### PR TITLE
[Reviewer: Andy] Clean install output

### DIFF
--- a/root/etc/clearwater/scripts/ellis
+++ b/root/etc/clearwater/scripts/ellis
@@ -12,5 +12,12 @@ sed -e 's/^\(SIP_DIGEST_REALM\) = .*$/\1 = "'$home_domain'"/g' \
     -e 's/^\(COOKIE_SECRET\) = .*$/\1 = "'$ellis_cookie_key'"/g' \
     -e 's/^\(API_KEY\) = .*$/\1 = "'$ellis_api_key'"/g' \
     </usr/share/clearwater/ellis/src/metaswitch/ellis/local_settings.py >/tmp/local_settings.py.$$
-cp /tmp/local_settings.py.$$ /usr/share/clearwater/ellis/src/metaswitch/ellis/local_settings.py
-mv /tmp/local_settings.py.$$ /usr/share/clearwater/ellis/env/lib/python2.7/site-packages/ellis-0.1-py2.7.egg/metaswitch/ellis/local_settings.py
+for dst in /usr/share/clearwater/ellis/src/metaswitch/ellis/local_settings.py \
+           /usr/share/clearwater/ellis/env/lib/python2.7/site-packages/ellis-0.1-py2.7.egg/metaswitch/ellis/local_settings.py
+do
+  if [ -f $dst ]
+  then
+    cp /tmp/local_settings.py.$$ $dst
+  fi
+done
+rm /tmp/local_settings.py.$$


### PR DESCRIPTION
Andy, please can you review my fix to get a clean install of ellis?  Previously, we sometimes got the following (benign) error.

```
 Setting up clearwater-infrastructure (1.0-130507.080417) ...
mv: cannot move `/tmp/local_settings.py.3919' to `/usr/share/clearwater/ellis/env/lib/python2.7/site-packages/ellis-0.1-py2.7.egg/metaswitch/ellis/local_settings.py': No such file or directory
```

This was because we hadn't yet installed ellis, and so hadn't unpacked its egg, so the directory exist.  The key point of my fix is to check that files (and hence their parent directories) exist before copying - if they don't, it's safe not to do the copy, because it will get fixed up later anyway.  The rest of the change (moving to the for loop) is just to make the code tidier.  A similar fix for crest will follow shortly.
