### PR TITLE
Reviewer Andy : Db sync

### DIFF
--- a/src/metaswitch/ellis/tools/sync_databases.py
+++ b/src/metaswitch/ellis/tools/sync_databases.py
@@ -68,8 +68,6 @@ stats = {"Assigned numbers in Ellis": 0,
 def create_get_handler(sip_uri, on_found=None, on_not_found=None):
     """
     Handler that asserts that a resource exists, executing the on_not_found handler if not
-    Pass keys in extract_keys for items to be extracted from the response and passed to
-    the handler, e.g. the private id
     """
     def handle_get(response):
         global pending_requests


### PR DESCRIPTION
Extended the db sync tool to deal with private ids. We now first check if we have a private id for a line, and if we don't, we clean up. If we do we use that private id to perform all the checks we did before. Namely, if we don't have a digest, delete the line and if we have no ifc, create the default ones.

Tested by running against my deployment and fiddling with the databases on ellis and homestead.
