### PR TITLE
[Reviewer: Andy] Fix issues about missing zc.buildout egg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ bin/buildout: $(ENV_DIR)/bin/python
 	cp thrift_download/thrift-0.8.0.tar.gz .buildout_downloads/dist/
 	$(ENV_DIR)/bin/easy_install zc.buildout
 	$(ENV_DIR)/bin/buildout
-	ln -s $(ENV_DIR)/bin/buildout ./bin/buildout
 
 $(ENV_DIR)/bin/python:
 	virtualenv --no-site-packages --distribute --python=$(PYTHON_BIN) $(ENV_DIR)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,7 @@
 [buildout]
 download-cache = .buildout_downloads
 parts =
+  zc.buildout
   coverage
   python
   tornado
@@ -24,6 +25,11 @@ develop =
   common
 eggs =
   metaswitchcommon
+
+[zc.buildout]
+recipe = zc.recipe.egg
+eggs =
+  zc.buildout ==2.2.0
 
 [coverage]
 recipe = zc.recipe.egg
@@ -69,6 +75,7 @@ eggs =
 recipe = zc.recipe.egg
 interpreter = python
 eggs =
+  ${zc.buildout:eggs}
   ${coverage:eggs}
   ${common:eggs}
   ${tornado:eggs}

--- a/debian/ellis.install
+++ b/debian/ellis.install
@@ -1,4 +1,5 @@
 eggs usr/share/clearwater/ellis/
+_env/lib/python2.7/site-packages/zc.buildout-2.2.0-py2.7.egg usr/share/clearwater/ellis/eggs/
 setup.py usr/share/clearwater/ellis/
 src usr/share/clearwater/ellis/
 web-content usr/share/clearwater/ellis/


### PR DESCRIPTION
Andy, as discussed, zc.buildout's egg was missing from the debian package following my earlier fix.  This reinstates it.
