### PR TITLE
Reviewer Matt - Correct monit configuration

### DIFF
--- a/ellis.monit
+++ b/ellis.monit
@@ -5,7 +5,7 @@ set daemon 10
 check process ellis pidfile /var/run/ellis/ellis.pid
   start program = "/etc/monit/run_logged /etc/init.d/ellis start"
   stop program = "/etc/monit/run_logged /etc/init.d/ellis stop"
-  if failed host localhost port 9888 type TCP protocol http
+  if failed host localhost port 80 type TCP protocol http
     and use the request "/ping" then restart
 # TODO monitor HTTPS as well as HTTP.
 #  if failed host localhost port 9443 type TCPSSL protocol http


### PR DESCRIPTION
Configure Monit to look at port 80, not 9888.
