### PR TITLE
[Reviewer: Ellie] Delete demo users when they expire

### DIFF
--- a/debian/ellis.cron.daily
+++ b/debian/ellis.cron.daily
@@ -50,7 +50,7 @@ for USER in $USERS
 do
   # Issue a curl request to delete the user, logging if this fails.
   logger -p daemon.notice -t ellis.cron.daily "Deleting expired user $USER"
-  OUT=$(curl -s -X DELETE -H "NGV-API-Key: ${ellis_api_key}" http://127.0.0.1/accounts/$USER) ||
+  OUT=$(curl -s -X DELETE -H "NGV-API-Key: ${ellis_api_key}" http://$local_ip/accounts/$USER) ||
   logger -p daemon.err -t ellis.cron.daily "curl reported error $? when deleting expired user $USER"
 
   # A successful delete returns no response.  If we got a response, log it.


### PR DESCRIPTION
Ellie,

Please can you review this (fixes #54)?  The issue is just that we no longer listen on 127.0.0.1, so we need to connect on the right IP.  Tested live (not UTs).

Matt
