### PR TITLE
[Reviewer: Andy] Mark ellis as the default server

### DIFF
--- a/root/usr/share/clearwater/infrastructure/scripts/create-ellis-nginx-config
+++ b/root/usr/share/clearwater/infrastructure/scripts/create-ellis-nginx-config
@@ -56,8 +56,8 @@ cat >> $site_file << EOF2
 }
 
 server {
-        listen       [::]:80; # ipv6only=off is set in the base config
-        server_name  ellis.$home_domain $local_ip $public_ip;
+        listen       [::]:80 default_server; # ipv6only=off is set in the base config
+        server_name  ellis.$home_domain $local_ip $public_ip $public_hostname;
 
         location / {
                 proxy_pass http://http_ellis;


### PR DESCRIPTION
Andy,

This is the second part (first part: https://github.com/Metaswitch/clearwater-nginx/pull/13) of my change that fixes #91.

This makes ellis the default server and (just for completeness really) adds its public hostname as a virtual host.

As for the first part, this has been live tested in various deployment types.

Matt