### PR TITLE
Reviewer AMC: Monit, don't kill mysql if system load goes above 10%

### DIFF
--- a/mysql.monit
+++ b/mysql.monit
@@ -6,5 +6,4 @@ check process mysql with pidfile /var/run/mysqld/mysqld.pid
     if cpu > 60% for 2 cycles then alert
     if cpu > 80% for 5 cycles then restart
     if totalmem > 150 MB for 5 cycles then restart
-    if loadavg(5min) greater than 10 for 8 cycles then stop
     if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
As discussed, this line looks wrong - monit shouldn't kill mysql just because system load has gone above 10% for a few minutes. Fully tested and documented.