### PR TITLE
[Reviewer: Rob] Wait for Ellis's tools to exit before stopping the server

### DIFF
--- a/debian/ellis.init.d
+++ b/debian/ellis.init.d
@@ -89,7 +89,13 @@ wait_for_tools()
       fi
     done
 
-    log_daemon_msg "Tools finished" "$NAME"
+    if tools_running; then
+      log_daemon_msg "Tools failed to exit" "$NAME"
+      return 1
+    else
+      log_daemon_msg "Tools finished" "$NAME"
+      return 0
+    fi
   fi
 }
 
@@ -127,7 +133,7 @@ do_stop()
         # Stopping Ellis terminates all processes that use its version of
         # python, including any of its tools. Wait for the tools to complete,
         # otherwise we can break automated installs.
-        wait_for_tools
+        wait_for_tools || return 2
 
         # Kill parent and children. Don't specify pidfile, or we'll kill only
         # the parent. This must be run while $DAEMON exists in the filesystem,


### PR DESCRIPTION
This PR makes Ellis's init script wait until Ellis's tools have exited before stopping the Ellis server. This is needed because the way that we stop Ellis is by terminating all processes that are using it's pytyhon executable, which includes tools like `create_numbers.py`. This in turn is breaking AIO node installs. 

The fix only waits for tools run from the `/usr/share/clearwater/ellis` directory, but that is enough to fix the AIO, and reduces the chance of false positives.

Tested by:

* Running `create_numbers.py` and `sudo service ellis restart` in parallel. The restart waits until `create_numbers.py` has finished.
* Running `sudo service ellis restart` on its own returned promptly.
* Using chef to spin up an AIO node. 