### PR TITLE
[Reviewer: Ellie] Enhance provisioning tools to support plaintext passwords

### DIFF
--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -47,6 +47,7 @@ def main():
     parser.add_argument("-k", "--keep-going", action="store_true", dest="keep_going", help="keep going on errors")
     parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="don't display the user")
     parser.add_argument("--hsprov", metavar="IP:PORT", action="store", help="IP address and port of homestead-prov")
+    parser.add_argument("--plaintext", action="store_true", help="store password in plaintext")
     parser.add_argument("--ifc", metavar="iFC-FILE", action="store", dest="ifc_file", help="XML file containing the iFC")
     parser.add_argument("--prefix", action="store", default="123", dest="twin_prefix", help="twin-prefix (default: 123)")
     parser.add_argument("dns", metavar="<directory-number>[...<directory-number>]")
@@ -68,7 +69,7 @@ def main():
         public_id = "sip:%s@%s" % (dn, args.domain)
         private_id = "%s@%s" % (dn, args.domain)
 
-        if utils.create_user(private_id, public_id, args.domain, args.password, ifc):
+        if utils.create_user(private_id, public_id, args.domain, args.password, ifc, plaintext=args.plaintext):
             if not args.quiet and not utils.display_user(private_id, public_id):
                 success = False
         else:

--- a/src/metaswitch/ellis/prov_tools/display_user.py
+++ b/src/metaswitch/ellis/prov_tools/display_user.py
@@ -64,7 +64,7 @@ def main():
         private_id = "%s@%s" % (dn, args.domain)
 
         if not utils.display_user(private_id, public_id, short=args.short):
-           success = False
+            success = False
 
         if not success and not args.keep_going:
             break

--- a/src/metaswitch/ellis/prov_tools/update_user.py
+++ b/src/metaswitch/ellis/prov_tools/update_user.py
@@ -47,6 +47,7 @@ def main():
     parser.add_argument("-k", "--keep-going", action="store_true", dest="keep_going", help="keep going on errors")
     parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="don't display the user")
     parser.add_argument("--hsprov", metavar="IP:PORT", action="store", help="IP address and port of homestead-prov")
+    parser.add_argument("--plaintext", action="store_true", help="store password in plaintext")
     parser.add_argument("dns", metavar="<directory-number>[...<directory-number>]")
     parser.add_argument("domain", metavar="<domain>")
     parser.add_argument("password", metavar="<password>")
@@ -63,7 +64,7 @@ def main():
         public_id = "sip:%s@%s" % (dn, args.domain)
         private_id = "%s@%s" % (dn, args.domain)
 
-        if utils.update_user(private_id, public_id, args.domain, args.password, None):
+        if utils.update_user(private_id, public_id, args.domain, args.password, None, plaintext=args.plaintext):
             if not args.quiet and not utils.display_user(private_id, public_id):
                 success = False
         else:

--- a/src/metaswitch/ellis/test/remote/homestead.py
+++ b/src/metaswitch/ellis/test/remote/homestead.py
@@ -125,6 +125,23 @@ class TestHomesteadPasswords(TestHomestead):
             follow_redirects=False,
             allow_ipv6=True)
 
+    @patch("tornado.httpclient.HTTPClient", new=MockHTTPClient)
+    @patch("tornado.httpclient.AsyncHTTPClient")
+    @patch("metaswitch.ellis.remote.homestead.settings")
+    def test_put_password_plaintext(self, settings, AsyncHTTPClient):
+        self.standard_setup(settings, AsyncHTTPClient)
+        body = json.dumps({"plaintext_password": "pw", "realm": "realm"})
+        callback = Mock()
+        homestead.put_password(PRIVATE_URI, "realm", "pw", callback, plaintext=True)
+        self.mock_httpclient.fetch.assert_called_once_with(
+            'http://homestead/private/pri%40foo.bar',
+            callback,
+            method='PUT',
+            body=body,
+            headers={'Content-Type': 'application/json'},
+            follow_redirects=False,
+            allow_ipv6=True)
+
 class TestHomesteadPrivateIDs(TestHomestead):
     """Tests for creating and deleting private IDs"""
 


### PR DESCRIPTION
Ellie,

Please can you review my fix to enhance provisioning tools to support plaintext passwords?

Tested live (as well as UT below):

```
$ ./create_user --plaintext 111111 mirw.cw-ngv.com secret
111111@mirw.cw-ngv.com:
  HA1 digest:
    6086e9f631bf739e7bb06f252b2f590b (secret)
  iFC:
    <?xml version="1.0" ?>
    <ServiceProfile>
    </ServiceProfile>
```

(Also works for update_user and display_user.)

Cheers,

Matt