### PR TITLE
[Reviewer: Rob] Implement list_users tool

### DIFF
--- a/clearwater-prov-tools.root/usr/share/clearwater/bin/list_users
+++ b/clearwater-prov-tools.root/usr/share/clearwater/bin/list_users
@@ -1,0 +1,1 @@
+../clearwater-prov-tools/src/metaswitch/ellis/prov_tools/list_users.py

--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -70,7 +70,7 @@ def main():
         private_id = "%s@%s" % (dn, args.domain)
 
         if utils.create_user(private_id, public_id, args.domain, args.password, ifc, plaintext=args.plaintext):
-            if not args.quiet and not utils.display_user(private_id, public_id):
+            if not args.quiet and not utils.display_user(public_id):
                 success = False
         else:
             success = False

--- a/src/metaswitch/ellis/prov_tools/list_users.py
+++ b/src/metaswitch/ellis/prov_tools/list_users.py
@@ -1,6 +1,6 @@
 #!/usr/share/clearwater/clearwater-prov-tools/env/bin/python
 
-# @file create_user.py
+# @file list_users.py
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2015  Metaswitch Networks Ltd
@@ -37,36 +37,70 @@
 import sys
 import logging
 import argparse
+import time
+
+from tornado.web import HTTPError
 from metaswitch.ellis import settings
 from metaswitch.ellis.prov_tools import utils
 
 _log = logging.getLogger();
 
+def pace_wrapper(iterator, pace=10):
+    next_time = time.time()
+    for item in iterator:
+        now_time = time.time()
+        if now_time < next_time:
+            time.sleep(next_time - now_time)
+        else:
+            next_time = now_time
+        next_time += 1.0 / pace
+        yield item
+
 def main():
-    parser = argparse.ArgumentParser(description="Display user")
+    parser = argparse.ArgumentParser(description="List users")
     parser.add_argument("-k", "--keep-going", action="store_true", dest="keep_going", help="keep going on errors")
-    parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="suppress errors when ignoring them")
-    parser.add_argument("-s", "--short", action="store_true", dest="short", help="less verbose display")
     parser.add_argument("--hsprov", metavar="IP:PORT", action="store", help="IP address and port of homestead-prov")
-    parser.add_argument("dns", metavar="<directory-number>[..<directory-number>]")
-    parser.add_argument("domain", metavar="<domain>")
+    parser.add_argument("--full", action="store_true", help="displays full information for each user")
+    parser.add_argument("--pace", action="store", help="sets the target number of users to list per second")
+    parser.add_argument("-f", "--force", action="store_true", dest="force", help="forces specified pace")
     args = parser.parse_args()
 
-    utils.setup_logging(level=logging.CRITICAL if args.quiet else logging.ERROR)
+    utils.setup_logging()
     settings.HOMESTEAD_URL = args.hsprov or settings.HOMESTEAD_URL
+    default_pace = 5 if args.full else 500
+    pace = int(args.pace) if args.pace else default_pace
+
+    # Check the pace and get confirmation if it's too high
+    if pace > default_pace and not args.force:
+        if args.full:
+            print("Pace %d greater than recommended value (%d) when --full specified" % (pace, default_pace))
+        else:
+            print("Pace %d greater than recommended value (%d)" % (pace, default_pace))
+        print("This may impact call processing!  Are you sure?")
+        print("Type <yes> below or rerun with --force to confirm")
+        if raw_input().lower() == "yes":
+            print("Continuing...")
+        else:
+            print("Aborting!")
+            sys.exit(1)
 
     if not utils.check_connection():
         sys.exit(1)
 
     success = True
-    for dn in utils.parse_dn_ranges(args.dns):
-        public_id = "sip:%s@%s" % (dn, args.domain)
+    try:
+        for public_id in pace_wrapper(utils.list_users(keep_going=args.keep_going), pace=pace):
+            if args.full:
+                if not utils.display_user(public_id):
+                    success = False
+            else:
+                print "%s" % (public_id,)
+            sys.stdout.flush()
 
-        if not utils.display_user(public_id, short=args.short):
-            success = False
-
-        if not success and not args.keep_going:
-            break
+            if not success and not args.keep_going:
+                break
+    except HTTPError:
+        success = False
 
     sys.exit(0 if success else 1)
 

--- a/src/metaswitch/ellis/prov_tools/list_users.py
+++ b/src/metaswitch/ellis/prov_tools/list_users.py
@@ -48,11 +48,11 @@ _log = logging.getLogger();
 def pace_wrapper(iterator, pace=10):
     next_time = time.time()
     for item in iterator:
-        now_time = time.time()
-        if now_time < next_time:
-            time.sleep(next_time - now_time)
+        now = time.time()
+        if now < next_time:
+            time.sleep(next_time - now)
         else:
-            next_time = now_time
+            next_time = now
         next_time += 1.0 / pace
         yield item
 
@@ -61,14 +61,14 @@ def main():
     parser.add_argument("-k", "--keep-going", action="store_true", dest="keep_going", help="keep going on errors")
     parser.add_argument("--hsprov", metavar="IP:PORT", action="store", help="IP address and port of homestead-prov")
     parser.add_argument("--full", action="store_true", help="displays full information for each user")
-    parser.add_argument("--pace", action="store", help="sets the target number of users to list per second")
+    parser.add_argument("--pace", action="store", type=int, help="sets the target number of users to list per second")
     parser.add_argument("-f", "--force", action="store_true", dest="force", help="forces specified pace")
     args = parser.parse_args()
 
     utils.setup_logging()
     settings.HOMESTEAD_URL = args.hsprov or settings.HOMESTEAD_URL
     default_pace = 5 if args.full else 500
-    pace = int(args.pace) if args.pace else default_pace
+    pace = args.pace or default_pace
 
     # Check the pace and get confirmation if it's too high
     if pace > default_pace and not args.force:
@@ -76,8 +76,8 @@ def main():
             print("Pace %d greater than recommended value (%d) when --full specified" % (pace, default_pace))
         else:
             print("Pace %d greater than recommended value (%d)" % (pace, default_pace))
-        print("This may impact call processing!  Are you sure?")
-        print("Type <yes> below or rerun with --force to confirm")
+        print("This may impact call processing!  Are you sure? [y/N]")
+        print("(... or specify --force to skip this check and force the specified pace)")
         if raw_input().lower() == "yes":
             print("Continuing...")
         else:

--- a/src/metaswitch/ellis/prov_tools/update_user.py
+++ b/src/metaswitch/ellis/prov_tools/update_user.py
@@ -65,7 +65,7 @@ def main():
         private_id = "%s@%s" % (dn, args.domain)
 
         if utils.update_user(private_id, public_id, args.domain, args.password, None, plaintext=args.plaintext):
-            if not args.quiet and not utils.display_user(private_id, public_id):
+            if not args.quiet and not utils.display_user(public_id):
                 success = False
         else:
             success = False

--- a/src/metaswitch/ellis/remote/homestead.py
+++ b/src/metaswitch/ellis/remote/homestead.py
@@ -264,6 +264,7 @@ def _http_request(url, callback, overload_retries=3, **kwargs):
     if 'follow_redirects' not in kwargs:
         kwargs['follow_redirects'] = False
     kwargs['allow_ipv6'] = True
+    # Use a holder for the retries value, so that the functions we define below can modify it.
     retries_holder = {'retries': overload_retries}
 
     def do_http_request():
@@ -275,6 +276,7 @@ def _http_request(url, callback, overload_retries=3, **kwargs):
         if response.code == 503 and retries_holder['retries'] > 1:
             _log.debug("503 response - retrying %d more time(s)..." % retries_holder['retries'])
             retries_holder['retries'] -= 1
+            # Set a timer to retry the HTTP request in 500ms.
             IOLoop.instance().add_timeout(datetime.timedelta(milliseconds=500), do_http_request)
         else:
             callback(response)


### PR DESCRIPTION
Rob,

Please can you review these changes for the `list_users` tool?

The bulk of the changes are in the `list_users.py` and `utils.py` file, but a few other points.

*   `utils.display_user` no longer takes the `private_id`, instead looking it up from the server, and displaying all that it finds

*   I've enhanced `homestead.http_request` and `homestead._sync_http_request` to retry (after a delay) if they get a 503 overload response - as well as improving behavior here, this improves ellis generally - the bulk of the UT cases are actually around this.

I've UT-ed and live-tested.  Docs will follow tomorrow.

Matt