### PR TITLE
[Reviewer: Graeme] Honour the spirit of the 204 No Content response

### DIFF
--- a/src/metaswitch/ellis/api/_base.py
+++ b/src/metaswitch/ellis/api/_base.py
@@ -273,7 +273,10 @@ class BaseHandler(tornado.web.RequestHandler, DbSessionMixin):
             self.redirect(redirect_url)
         else:
             self.set_status(status_code)
-            self.finish(data)
+            if status_code == httplib.NO_CONTENT:
+                self.finish()
+            else:
+                self.finish(data)
 
     def forward_error(self, response):
         """


### PR DESCRIPTION
Account deletion returns 204 No Content but a body of '{}', that's terribly sad (and breaks the Java Apache HttpComponents client), this fixes it and stops us getting it wrong again.