### PR TITLE
Reviewer Rob - Select and allocate numbers from the database atomically

### DIFF
--- a/src/metaswitch/ellis/test/data/numbers.py
+++ b/src/metaswitch/ellis/test/data/numbers.py
@@ -138,8 +138,7 @@ class TestNumbers(BaseDataTest):
 
     @patch("random.randint")
     def test_allocate_number_not_found(self, randint):
-        randint.return_value = 0
-        self.mock_cursor.fetchone.return_value = None
+        self.mock_cursor.fetchone.return_value = (None, )
         self.assertRaises(NotFound, allocate_number, self.mock_session, OWNER_ID)
 
     def test_get_number(self):


### PR DESCRIPTION
Allocate numbers in Ellis's database as they are selected (rather than doing it in two phases which is susceptible to races).

Fix suggested by @mbt-msw who's tested it live (and I've updated the UTs to match).