### PR TITLE
[Reviewer: Matt] More robustness in start-stop-daemon

### DIFF
--- a/debian/ellis.init.d
+++ b/debian/ellis.init.d
@@ -73,18 +73,18 @@ SCRIPTNAME=/etc/init.d/$NAME
 #
 do_start()
 {
-	# Return
-	#   0 if daemon has been started
-	#   1 if daemon was already running
-	#   2 if daemon could not be started
-  
+  # Return
+  #   0 if daemon has been started
+  #   1 if daemon was already running
+  #   2 if daemon could not be started
+
   [ -d /var/run/$NAME ] || install -m 755 -o $USER -g root -d /var/run/$NAME
 
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
-		|| return 1
-	start-stop-daemon --start --quiet --chdir $DAEMON_DIR --chuid $USER --pidfile $PIDFILE --exec $DAEMON -- \
-		$DAEMON_ARGS --background \
-		|| return 2
+    || return 1
+  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --chuid $USER --pidfile $PIDFILE --exec $DAEMON -- \
+    $DAEMON_ARGS --background \
+    || return 2
 }
 
 #
@@ -111,9 +111,9 @@ do_stop()
 #
 do_run()
 {
-        [ -d /var/run/$NAME ] || install -m 755 -o $USER -g root -d /var/run/$NAME
-        start-stop-daemon --start --quiet --chdir $DAEMON_DIR --chuid $USER --exec $DAEMON -- $DAEMON_ARGS \
-                || return 2
+  [ -d /var/run/$NAME ] || install -m 755 -o $USER -g root -d /var/run/$NAME
+  start-stop-daemon --start --quiet --chdir $DAEMON_DIR --chuid $USER --exec $DAEMON -- $DAEMON_ARGS \
+    || return 2
 }
 
 #
@@ -139,86 +139,86 @@ case "$1" in
     [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
     do_start
     case "$?" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-	esac
-  ;;
+      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
   stop)
-	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-	do_stop
-	case "$?" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-	esac
-	;;
+    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+    do_stop
+    case "$?" in
+      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
   run)
-        [ "$VERBOSE" != no ] && log_daemon_msg "Running $DESC" "$NAME"
-        do_run
-        case "$?" in
-          0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-          2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-        esac
-        ;;
+    [ "$VERBOSE" != no ] && log_daemon_msg "Running $DESC" "$NAME"
+    do_run
+    case "$?" in
+      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
   status)
-       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
-       ;;
+    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
   #reload|force-reload)
-	#
-	# If do_reload() is not implemented then leave this commented out
-	# and leave 'force-reload' as an alias for 'restart'.
-	#
-	#log_daemon_msg "Reloading $DESC" "$NAME"
-	#do_reload
-	#log_end_msg $?
-	#;;
+    #
+    # If do_reload() is not implemented then leave this commented out
+    # and leave 'force-reload' as an alias for 'restart'.
+    #
+    #log_daemon_msg "Reloading $DESC" "$NAME"
+    #do_reload
+    #log_end_msg $?
+    #;;
   restart|force-reload)
-	#
-	# If the "reload" option is implemented then remove the
-	# 'force-reload' alias
-	#
-	log_daemon_msg "Restarting $DESC" "$NAME"
-	do_stop
-	case "$?" in
-	  0|1)
-		do_start
-		case "$?" in
-			0) log_end_msg 0 ;;
-			1) log_end_msg 1 ;; # Old process is still running
-			*) log_end_msg 1 ;; # Failed to start
-		esac
-		;;
-	  *)
-	  	# Failed to stop
-		log_end_msg 1
-		;;
-	esac
-	;;
-  abort)
-	log_daemon_msg "Aborting $DESC" "$NAME"
-	do_abort
-	;;
-  abort-restart)
-        log_daemon_msg "Abort-Restarting $DESC" "$NAME"
-        do_abort
+    #
+    # If the "reload" option is implemented then remove the
+    # 'force-reload' alias
+    #
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    do_stop
+    case "$?" in
+      0|1)
+        do_start
         case "$?" in
-          0|1)
-                do_start
-                case "$?" in
-                        0) log_end_msg 0 ;;
-                        1) log_end_msg 1 ;; # Old process is still running
-                        *) log_end_msg 1 ;; # Failed to start
-                esac
-                ;;
-          *)
-                # Failed to stop
-                log_end_msg 1
-                ;;
+          0) log_end_msg 0 ;;
+          1) log_end_msg 1 ;; # Old process is still running
+          *) log_end_msg 1 ;; # Failed to start
         esac
         ;;
+      *)
+        # Failed to stop
+        log_end_msg 1
+      ;;
+    esac
+    ;;
+  abort)
+    log_daemon_msg "Aborting $DESC" "$NAME"
+    do_abort
+    ;;
+  abort-restart)
+    log_daemon_msg "Abort-Restarting $DESC" "$NAME"
+    do_abort
+    case "$?" in
+      0|1)
+        do_start
+        case "$?" in
+          0) log_end_msg 0 ;;
+          1) log_end_msg 1 ;; # Old process is still running
+          *) log_end_msg 1 ;; # Failed to start
+        esac
+        ;;
+      *)
+      # Failed to stop
+      log_end_msg 1
+      ;;
+    esac
+    ;;
   *)
-	echo "Usage: $SCRIPTNAME {start|stop|run|status|restart|force-reload|abort|abort-restart}" >&2
-	exit 3
-	;;
+    echo "Usage: $SCRIPTNAME {start|stop|run|status|restart|force-reload|abort|abort-restart}" >&2
+    exit 3
+    ;;
 esac
 
 :

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.ellis.test',
-    install_requires=["py-bcrypt", "tornado==2.3", "msgpack-python", "phonenumbers", "SQLAlchemy", "MySQL-python"],
+    install_requires=["py-bcrypt", "tornado==2.3", "msgpack-python", "phonenumbers", "SQLAlchemy", "MySQL-python", "prctl"],
     tests_require=["pbr==1.6", "Mock"]
     )

--- a/src/metaswitch/ellis/main.py
+++ b/src/metaswitch/ellis/main.py
@@ -38,6 +38,8 @@
 import os
 import argparse
 import logging
+import prctl
+import signal
 import tornado.web
 import tornado.ioloop
 import tornado.process
@@ -72,6 +74,8 @@ def standalone():
     parser.add_argument("--background", action="store_true", help="Detach and run server in background")
     args = parser.parse_args()
 
+    prctl.prctl(prctl.NAME, "ellis")
+
     # We don't initialize logging until we fork because we want each child to
     # have its own logging and it's awkward to reconfigure logging that is
     # defined by the parent.
@@ -89,16 +93,23 @@ def standalone():
 
     utils.install_sigusr1_handler(settings.LOG_FILE_PREFIX)
 
-    # Drop a pidfile.
-    pid = os.getpid()
-    with open(settings.PID_FILE, "w") as pidfile:
-        pidfile.write(str(pid) + "\n")
+    # Drop a pidfile. We must keep a reference to the file object here, as this keeps
+    # the file locked and provides extra protection against two processes running at
+    # once.
+    pidfile_lock = None
+    try:
+        pidfile_lock = utils.lock_and_write_pid_file(settings.PID_FILE) # noqa
+    except IOError:
+        # We failed to take the lock - another process is already running
+        exit(1)
 
     # Fork off a child process per core.  In the parent process, the
     # fork_processes call blocks until the children exit.
     num_processes = settings.TORNADO_PROCESSES_PER_CORE * tornado.process.cpu_count()
     task_id = tornado.process.fork_processes(num_processes)
     if task_id is not None:
+        prctl.prctl(prctl.NAME, "ellis")
+        prctl.prctl(prctl.PDEATHSIG, signal.SIGTERM)
         logging_config.configure_logging(settings.LOG_LEVEL, settings.LOGS_DIR, settings.LOG_FILE_PREFIX, task_id)
         # We're a child process, start up.
         _log.info("Process %s starting up", task_id)

--- a/src/metaswitch/ellis/settings.py
+++ b/src/metaswitch/ellis/settings.py
@@ -68,7 +68,7 @@ LOG_FILE_PREFIX = "ellis"
 LOG_FILE_MAX_BYTES = 10000000
 LOG_BACKUP_COUNT = 10
 LOG_LEVEL = logging.INFO
-PID_FILE = os.path.join(PROJECT_DIR, "server.pid")
+PID_FILE = "/var/run/ellis/ellis.pid"
 
 # Tornado cookie encryption key.  Tornado instances that share this key will
 # all trust each other's cookies.


### PR DESCRIPTION
This PR:

* makes the main Ellis process write out a pidfile (with file locking so it can't be trampled)
* makes start-stop-daemon monitor and kill Ellis with that pidfile
* sets a parent death signal in the child processes, so that they get a SIGTERM when their parent dies
* renames the process from "python" to "ellis" - not for start-stop-daemon purposes, but for diagnostics
* adds prctl as a dependency