### PR TITLE
[Reviewer Andy] Fix TypeError when receiving 404 for getting private IDs

### DIFF
--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -226,7 +226,7 @@ def display_user(public_id, short=False):
                 _log.error("Failed to retrieve digest for private ID %s - HTTP status code %d", private_id, response.code)
                 success = False
     else:
-        _log.error("Failed to retrieve private IDs for public ID - HTTP status code %d", public_id, response.code)
+        _log.error("Failed to retrieve private IDs for public ID %s - HTTP status code %d", public_id, response.code)
         success = False
 
     if not short:


### PR DESCRIPTION
Hi Andy,

Please could you review?

This a fix to the error logging if we receive a 404 response to requesting the private ID in utils.display_user.

Tested on a test deployment.