### PR TITLE
[Reviewer AMC] Allow iFC to be changed by update_user

### DIFF
--- a/src/metaswitch/ellis/prov_tools/update_user.py
+++ b/src/metaswitch/ellis/prov_tools/update_user.py
@@ -48,13 +48,21 @@ def main():
     parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="don't display the user")
     parser.add_argument("--hsprov", metavar="IP:PORT", action="store", help="IP address and port of homestead-prov")
     parser.add_argument("--plaintext", action="store_true", help="store password in plaintext")
+    parser.add_argument("--ifc", metavar="iFC-FILE", action="store", dest="ifc_file", help="XML file containing the iFC")
+    parser.add_argument("--prefix", action="store", default="123", dest="twin_prefix", help="twin-prefix (default: 123)")
     parser.add_argument("dns", metavar="<directory-number>[..<directory-number>]")
     parser.add_argument("domain", metavar="<domain>")
-    parser.add_argument("password", metavar="<password>")
+    parser.add_argument("--password", metavar="<password>")
     args = parser.parse_args()
 
     utils.setup_logging()
     settings.HOMESTEAD_URL = args.hsprov or settings.HOMESTEAD_URL
+
+    ifc = None
+    if args.ifc_file:
+        ifc = utils.build_ifc(args.ifc_file, args.domain, args.twin_prefix)
+        if not ifc:
+            sys.exit(1)
 
     if not utils.check_connection():
         sys.exit(1)
@@ -64,7 +72,7 @@ def main():
         public_id = "sip:%s@%s" % (dn, args.domain)
         private_id = "%s@%s" % (dn, args.domain)
 
-        if utils.update_user(private_id, public_id, args.domain, args.password, None, plaintext=args.plaintext):
+        if utils.update_user(private_id, public_id, args.domain, args.password, ifc, args.plaintext):
             if not args.quiet and not utils.display_user(public_id):
                 success = False
         else:


### PR DESCRIPTION
This change adds the ability to update_user to modify the iFC file of a subscriber added through create_user.  As update_user is now no longer solely for the purpose of updating the password, the password field becomes an optional parameter in update_user (and requires a "--password" option to be specified in front of the new password if it is to be changed).

The change also tidies away a spurious "plaintext=.." in the arguments to a function call.

Tested using an iFC file with DOMAIN and PREFIX substitute strings to confirm that the new --prefix option also works.  Each of the three update options (password changed only, iFC changed only, both password and iFC changed) was tested, as was the "iFC file missing" error path and the defaulting of prefix to "123".