### PR TITLE
[Reviewer: Andy] Improve Homestead-prov script's UX

### DIFF
--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -70,7 +70,7 @@ def main():
         private_id = "%s@%s" % (dn, args.domain)
 
         if utils.create_user(private_id, public_id, args.domain, args.password, ifc, plaintext=args.plaintext):
-            if not args.quiet and not utils.display_user(public_id):
+            if not args.quiet and not utils.display_user(public_id, quiet=True):
                 success = False
         else:
             success = False

--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -70,7 +70,7 @@ def main():
         private_id = "%s@%s" % (dn, args.domain)
 
         if utils.create_user(private_id, public_id, args.domain, args.password, ifc, plaintext=args.plaintext):
-            if not args.quiet and not utils.display_user(public_id, quiet=True):
+            if not utils.display_user(public_id, quiet=True):
                 success = False
         else:
             success = False

--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -197,14 +197,18 @@ def delete_user(private_id, public_id, force=False):
 
     return success
 
+def conditional_print(condition, text):
+    if condition:
+        print text
+
 # quiet flag will prevent any output to stdout. This way we can check that the
 # user exists and has valid xml, without swamping the output with large iFCs
 def display_user(public_id, short=False, quiet=False):
     success = True
     callback = Callback()
 
-    if not short and not quiet:
-        print "Public User ID %s:" % (public_id,)
+    if not short:
+        conditional_print(not quiet, "Public User ID %s:" % (public_id))
 
     homestead.get_associated_privates(public_id, callback)
     response = callback.wait()[0]
@@ -220,11 +224,11 @@ def display_user(public_id, short=False, quiet=False):
                     password = av['digest_ha1']
                     if 'plaintext_password' in av:
                         password += " (%s)" % (av['plaintext_password'],)
-                    if short and not quiet:
-                        print "%s/%s: %s" % (public_id, private_id, password)
-                    elif not quiet:
-                        print "  Private User ID %s:" % (private_id,)
-                        print "    HA1 digest: %s" % (password,)
+                    if short:
+                        conditional_print(not quiet, "%s/%s: %s" % (public_id, private_id, password))
+                    else:
+                        conditional_print(not quiet, "  Private User ID %s:" % (private_id,))
+                        conditional_print(not quiet, "    HA1 digest: %s" % (password,))
             else:
                 _log.error("Failed to retrieve digest for private ID %s - HTTP status code %d", private_id, response.code)
                 success = False
@@ -245,9 +249,8 @@ def display_user(public_id, short=False, quiet=False):
             ifc_str = "\n".join(filter(lambda l: l.strip() != "", ifc_str.split("\n")))
             ifc_str = "    " + ifc_str.replace("\n", "\n    ")
 
-            if not quiet:
-                print "  iFC:"
-                print ifc_str
+            conditional_print(not quiet, "  iFC:")
+            conditional_print(not quiet, ifc_str)
         else:
             _log.error("Failed to retrieve iFC for public ID %s - HTTP status code %d", public_id, response.code)
             success = False

--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -199,6 +199,7 @@ def delete_user(private_id, public_id, force=False):
 
 def display_user(public_id, short=False):
     success = True
+    user_missing = False
     callback = Callback()
 
     if not short:
@@ -227,6 +228,8 @@ def display_user(public_id, short=False):
                 success = False
     else:
         _log.error("Failed to retrieve private IDs for public ID %s - HTTP status code %d", public_id, response.code)
+        if response.code == 404:
+            user_missing = True
         success = False
 
     if not short:
@@ -241,7 +244,12 @@ def display_user(public_id, short=False):
             print ifc_str
         else:
             _log.error("Failed to retrieve iFC for public ID %s - HTTP status code %d", public_id, response.code)
+            if response.code == 404:
+                user_missing = user_missing and True
             success = False
+
+    if user_missing:
+        _log.error("Failed to find any information for public ID %s.", public_id)
 
     return success
 

--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -197,6 +197,8 @@ def delete_user(private_id, public_id, force=False):
 
     return success
 
+# quiet flag will prevent any output to stdout. This way we can check that the
+# user exists and has valid xml, without swamping the output with large iFCs
 def display_user(public_id, short=False, quiet=False):
     success = True
     callback = Callback()


### PR DESCRIPTION
Hi Andy,

The context for this fix is that running `create_user` for a user that already exists gives the error 
> ERROR: Private ID num@example.com already exists - not creating

which is then swamped off the screen by displaying the data stored for the existing user, including iFC.

Additionally, I added an extra error to the `display_user` and `update_user` scripts when all requests return 404, to suggest that the user likely doesn't exist - as opposed to some freak database corruption leaving only partial user data. The old error message was:

>ERROR: Failed to retrieve iFC for public ID sip:num@example.com - HTTP status code 404

Tested on a test box. Please could you review?

Thanks,
Tom