### PR TITLE
Reviewer: AMC] Preserve leading 0 on create user

### DIFF
--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -84,10 +84,11 @@ def parse_dn_ranges(dn_ranges):
             continue
 
         # Strip the prefix, iterate through the resulting numbers and yield them
+        suffix_len = len(start_dn) - len(dn_prefix)
         start_num = int(start_dn[len(dn_prefix):])
         end_num = int(end_dn[len(dn_prefix):])
         for num in range(start_num, end_num + 1):
-            yield "%s%d" % (dn_prefix, num)
+            yield "%s%0*d" % (dn_prefix, suffix_len, num)
 
 def build_ifc(ifc_file, domain, twin_prefix):
     """

--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -87,7 +87,7 @@ def parse_dn_ranges(dn_ranges):
         suffix_len = len(start_dn) - len(dn_prefix)
         start_num = int(start_dn[len(dn_prefix):])
         end_num = int(end_dn[len(dn_prefix):])
-        for num in range(start_num, end_num + 1):
+        for num in xrange(start_num, end_num + 1):
             yield "%s%0*d" % (dn_prefix, suffix_len, num)
 
 def build_ifc(ifc_file, domain, twin_prefix):


### PR DESCRIPTION
Hi Andy,

This is a fix for an issue that causes leading 0s to be stripped off the numbers of created users. Additionally I fixed a bug causing a MemoryError when trying to provision a large number of subscribers.

Tested live.

Please could you review?

Thanks,
Tom