### PR TITLE
[Reviewer: Ellie] Clear out failed numbers if Homestead doesn't know about them

### DIFF
--- a/src/metaswitch/ellis/api/numbers.py
+++ b/src/metaswitch/ellis/api/numbers.py
@@ -118,6 +118,8 @@ class NumbersHandler(_base.LoggedInHandler):
             _log.debug("Returning %s to the pool", sip_uri)
             numbers.remove_owner(db_sess, sip_uri)
             db_sess.commit()
+            # Also try and remove it from Homer, but do nothing if we fail
+            xdm.delete_simservs(sip_uri, lambda responses: None)
             
         self.forward_error(response)
 

--- a/src/metaswitch/ellis/api/numbers.py
+++ b/src/metaswitch/ellis/api/numbers.py
@@ -113,9 +113,10 @@ class NumbersHandler(_base.LoggedInHandler):
 
     def _on_get_failure(self, sip_uri, response):
         _log.warn("Failed to fetch private identities from homestead for %s", sip_uri)
-        if isinstance(response, tornado.httpclient.HTTPError) and response.code == 404:
+        if hasattr(response, 'code') and response.code == 404:
             # The number has no records in Homestead, so forget about it locally
-            _log.debug("Returning %s to the pool", sip_uri)
+            _log.warn("Returning %s to the pool", sip_uri)
+            db_sess = self.db_session()
             numbers.remove_owner(db_sess, sip_uri)
             db_sess.commit()
             # Also try and remove it from Homer, but do nothing if we fail

--- a/src/metaswitch/ellis/test/api/test_numbers.py
+++ b/src/metaswitch/ellis/test/api/test_numbers.py
@@ -91,7 +91,8 @@ class TestNumbersHandler(BaseTest):
         # Assert that we kick off asynchronous GET at homestead
         self.handler.get_and_check_user_id.assert_called_once_with("foobar")
         HTTPCallbackGroup.assert_called_once_with(ANY, # functools.partial object
-                                                  self.handler._on_get_failure)
+                                                  ANY  # functools.partial object
+                                                  )
 
         get_associated_privates.assert_called_once_with(SIP_URI,
                                                         ANY # function


### PR DESCRIPTION
This should fix #174.

I'll test by:
* marking a number as created in the Ellis database, but not creating it in Homestead
* running the live tests, which will try to clean up that number
* checking that the live tests don't report an error, and that number is freed up in Ellis' database