### PR TITLE
Switch from Python version of bracket_ipv6_address to C++ version

### DIFF
--- a/root/usr/share/clearwater/bin/poll_ellis.sh
+++ b/root/usr/share/clearwater/bin/poll_ellis.sh
@@ -35,7 +35,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 . /etc/clearwater/config
-http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 
 http_url=http://$http_ip/ping
 ssl_cert_file=/etc/nginx/ssl/ellis.crt

--- a/root/usr/share/clearwater/bin/poll_ellis_https.sh
+++ b/root/usr/share/clearwater/bin/poll_ellis_https.sh
@@ -35,7 +35,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 . /etc/clearwater/config
-https_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+https_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 
 https_domain=${ellis_hostname:-ellis.$home_domain}
 https_url=https://$https_domain/ping


### PR DESCRIPTION
Same as https://github.com/Metaswitch/clearwater-infrastructure/pull/332, but for this repo.