### PR TITLE
[Reviewer: Rob] Use --always-unzip to avoid needing to run tools as a particular user

### DIFF
--- a/debian/clearwater-prov-tools.postinst
+++ b/debian/clearwater-prov-tools.postinst
@@ -62,7 +62,7 @@ case "$1" in
         fi
 
         virtualenv --python=$(which python) $TOOLS_DIR/env
-        $TOOLS_DIR/env/bin/easy_install --allow-hosts=None -f $TOOLS_DIR/.eggs/ $TOOLS_DIR/.eggs/*.egg
+        $TOOLS_DIR/env/bin/easy_install --allow-hosts=None --always-unzip -f $TOOLS_DIR/.eggs/ $TOOLS_DIR/.eggs/*.egg
         chown -R $NAME:root $TOOLS_DIR
         
         mkdir -p /var/log/clearwater-prov-tools

--- a/debian/ellis.postinst
+++ b/debian/ellis.postinst
@@ -67,7 +67,7 @@ case "$1" in
         chown -R $NAME:root /var/log/$NAME
 
         virtualenv --python=$(which python) $ELLIS_DIR/env
-        $ELLIS_DIR/env/bin/easy_install --allow-hosts=None -f $ELLIS_DIR/.eggs/ $ELLIS_DIR/.eggs/*.egg
+        $ELLIS_DIR/env/bin/easy_install --allow-hosts=None --always-unzip -f $ELLIS_DIR/.eggs/ $ELLIS_DIR/.eggs/*.egg
         chown -R $NAME:root $ELLIS_DIR
 
         mysql -u root --password= < $ELLIS_DIR/schema.sql


### PR DESCRIPTION
Rob,

Please can you review this fix to https://github.com/Metaswitch/crest/issues/271?  I've tested live.

One thing I'm not sure about is whether we should apply `--always-unzip` to other packages?  It doesn't seem required, but it might be best for consistency - thoughts?

Matt