### PR TITLE
[Reviewer: Rob] Docs fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,22 +56,22 @@ $(ENV_DIR)/bin/python: setup.py common/setup.py
 	virtualenv --setuptools --python=$(PYTHON_BIN) $(ENV_DIR)
 	$(ENV_DIR)/bin/easy_install "setuptools>0.7"
 	$(ENV_DIR)/bin/easy_install distribute
-	
+
 ${ENV_DIR}/.eggs_installed : $(ENV_DIR)/bin/python $(shell find src/metaswitch -type f -not -name "*.pyc") $(shell find common/metaswitch -type f -not -name "*.pyc")
 	# Generate .egg files for ellis and python-common
 	${ENV_DIR}/bin/python setup.py bdist_egg -d .eggs
 	cd common && EGG_DIR=../.eggs make build_common_egg
-	
+
 	${ENV_DIR}/bin/python src/metaswitch/ellis/prov_tools/setup.py bdist_egg -d .prov_tools_eggs
 	cd common && EGG_DIR=../.prov_tools_eggs make build_common_egg
 
 	# Download the egg files they depend upon
 	${ENV_DIR}/bin/easy_install -zmaxd .eggs/ .eggs/*.egg
 	${ENV_DIR}/bin/easy_install -zmaxd .prov_tools_eggs/ .prov_tools_eggs/*.egg
-	
+
 	# Install the downloaded egg files (this should match the postinst)
 	${ENV_DIR}/bin/easy_install --allow-hosts=None -f .eggs/ .eggs/*.egg
-	
+
 	# Touch the sentinel file
 	touch $@
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,7 +44,7 @@ If you are using git, you can check out the Ellis codebase with
 This accesses the repository over SSH on Github, and will not work unless you have a Github account and registered SSH key. If you do not have both of these, you will need to configure Git to read over HTTPS instead:
 
     git config --global url."https://github.com/".insteadOf git@github.com:
-    git clone --recursive git@github.com:Metaswitch/ellis.git 
+    git clone --recursive git@github.com:Metaswitch/ellis.git
 
 Building
 ========
@@ -153,11 +153,11 @@ Startup logs (from Monit) are written to `/var/log/monit.log` and
 `/var/log/syslog`.
 
 Ellis logs are written to `/var/log/ellis/`. The logging level is set
-to INFO by default. To also view DEBUG logs add the following to 
+to INFO by default. To also view DEBUG logs add the following to
 `local_settings.py`
 
     LOG_LEVEL = logging.DEBUG
-    
+
 To run the server as part of development use:
 
     make run

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,15 +57,7 @@ As part of the environment, a special python executable is generated in the
 `bin/` subdirectory.  That executable is preconfigured to use the correct
 `PYTHONPATH` to pick up the dependencies in the `_env/` directory.
 
-To build the code, you will need to make the environment, then run the
-set up scripts. This is done by the following commands (run from the top level
-Ellis directory):
-
-    make env
-    _env/bin/easy_install --allow-hosts=None -f eggs/ eggs/*.egg
-    _env/bin/python setup.py install
-    cd common
-    ../_env/bin/python setup.py install
+To build the code, run `make env` in the top level Ellis directory.
 
 To build the Debian package, type `make deb` (or `make deb-only` if
 you have already built the code). This creates a Debian package in

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,15 +49,16 @@ This accesses the repository over SSH on Github, and will not work unless you ha
 Building
 ========
 
-The build requires GNU Make. It uses virtualenv and buildout to create
-a virtual Python environment in `_env/` containing only the required
-dependencies, at the expected versions.
+The build requires GNU Make. It uses virtualenv to create a virtual Python
+environment in `_env/` containing only the required dependencies, at the
+expected versions, and then install the Ellis code into it.
 
 As part of the environment, a special python executable is generated in the
 `bin/` subdirectory.  That executable is preconfigured to use the correct
 `PYTHONPATH` to pick up the dependencies in the `_env/` directory.
 
-To build the code, run `make env` in the top level Ellis directory.
+To create the virtual environment and install the code, run `make env` in the
+top level Ellis directory.
 
 To build the Debian package, type `make deb` (or `make deb-only` if
 you have already built the code). This creates a Debian package in


### PR DESCRIPTION
Rob, can you please review this, as you make the changes to remove `setup.py install` from the postinst scripts. The first commit just contains whitespace changes.

Remove the steps after `make env` in the build process.

`easy_install` is already run as part of `make env`, but with the
correct args.

The `setup.py` commands were taken from the postinst scripts. They
have since been removed as they are no longer needed. Let's remove
them from here too.