### PR TITLE
[Reviewer: Ellie] Use Clearwater's user settings for the log level

### DIFF
--- a/debian/ellis.init.d
+++ b/debian/ellis.init.d
@@ -69,6 +69,26 @@ SCRIPTNAME=/etc/init.d/$NAME
 . /lib/lsb/init-functions
 
 #
+# Determine runtime settings
+#
+get_settings()
+{
+  log_level=2
+
+  . /etc/clearwater/config
+}
+
+#
+# Function to get the arguments to pass to the process
+#
+get_daemon_args()
+{
+  # Get the settings
+  get_settings
+
+  DAEMON_ARGS="$DAEMON_ARGS --log-level $log_level"
+}
+#
 # Function that starts the daemon/service
 #
 do_start()
@@ -82,6 +102,7 @@ do_start()
 
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
     || return 1
+  get_daemon_args
   start-stop-daemon --start --quiet --chdir $DAEMON_DIR --chuid $USER --pidfile $PIDFILE --exec $DAEMON -- \
     $DAEMON_ARGS --background \
     || return 2

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,14 +146,9 @@ Startup logs (from Monit) are written to `/var/log/monit.log` and
 `/var/log/syslog`.
 
 Ellis logs are written to `/var/log/ellis/`. The logging level is set
-to INFO by default. To also view DEBUG logs add the following to
-`local_settings.py`
-
-    LOG_LEVEL = logging.DEBUG
-
-To run the server as part of development use:
-
-    make run
+to INFO by default. To also view DEBUG logs, add `log_level=5`
+to `/etc/clearwater/user_settings` - creating this file if it doesn't
+exist, and then restarting ellis.
 
 Testing
 =======

--- a/src/metaswitch/ellis/main.py
+++ b/src/metaswitch/ellis/main.py
@@ -71,6 +71,7 @@ def standalone():
     # Parse arguments
     parser = argparse.ArgumentParser(description="Ellis web server")
     parser.add_argument("--background", action="store_true", help="Detach and run server in background")
+    parser.add_argument("--log-level", default=2, type=int)
     args = parser.parse_args()
 
     prctl.prctl(prctl.NAME, "ellis")
@@ -105,7 +106,10 @@ def standalone():
     # Only run one process, not one per core - we don't need the performance
     # and this keeps everything in one log file
     prctl.prctl(prctl.NAME, "ellis")
-    logging_config.configure_logging(settings.LOG_LEVEL, settings.LOGS_DIR, settings.LOG_FILE_PREFIX)
+    logging_config.configure_logging(
+            utils.map_clearwater_log_level(args.log_level),
+            settings.LOGS_DIR,
+            settings.LOG_FILE_PREFIX)
     _log.info("Ellis process starting up")
     connection.init_connection()
 

--- a/src/metaswitch/ellis/settings.py
+++ b/src/metaswitch/ellis/settings.py
@@ -33,7 +33,6 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 import os
-import logging
 
 """
 This file contains default settings for Homestead.  To override a setting
@@ -67,7 +66,6 @@ STATIC_DIR = os.path.join(PROJECT_DIR, "web-content")
 LOG_FILE_PREFIX = "ellis"
 LOG_FILE_MAX_BYTES = 10000000
 LOG_BACKUP_COUNT = 10
-LOG_LEVEL = logging.INFO
 PID_FILE = "/var/run/ellis/ellis.pid"
 
 # Tornado cookie encryption key.  Tornado instances that share this key will


### PR DESCRIPTION
Use Clearwater's user settings for the log level, instead of local_settings.py.