### PR TITLE
[Reviewer: RKD] Add pycurl as a explicit dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,14 @@ setup(
         '': ['*.eml'],
         },
     test_suite='metaswitch.ellis.test',
-    install_requires=["py-bcrypt", "tornado==2.3", "msgpack-python==0.4.6", "phonenumbers==7.1.1", "SQLAlchemy==1.0.9", "MySQL-python==1.2.5", "prctl"],
+    install_requires=[
+        "py-bcrypt",
+        "tornado==2.3",
+        "msgpack-python==0.4.6",
+        "phonenumbers==7.1.1",
+        "SQLAlchemy==1.0.9",
+        "MySQL-python==1.2.5",
+        "prctl",
+        "pycurl"],
     tests_require=["pbr==1.6", "Mock"]
     )

--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,13 @@ setup(
         },
     test_suite='metaswitch.ellis.test',
     install_requires=[
-        "py-bcrypt",
+        "py-bcrypt==0.4",
         "tornado==2.3",
         "msgpack-python==0.4.6",
         "phonenumbers==7.1.1",
         "SQLAlchemy==1.0.9",
         "MySQL-python==1.2.5",
-        "prctl",
-        "pycurl"],
+        "prctl==1.0.1",
+        "pycurl==7.43.0"],
     tests_require=["pbr==1.6", "Mock"]
     )


### PR DESCRIPTION
Rob,

This fixes https://github.com/Metaswitch/ellis/issues/188 by making pycurl an explicit dependancy of ellis.

pycurl is required because we explicitly require it to be installed for sync_database.py -https://github.com/Metaswitch/ellis/blob/dev/src/metaswitch/ellis/tools/sync_databases.py#L53

I've also marked everything as an explicit version -for the missing ones,  I've just taken the versions that were installed by default when I built.