### PR TITLE
[Reviewer: RJW2] Specify ipv6only=off in ellis nginx config

### DIFF
--- a/root/usr/share/clearwater/infrastructure/scripts/create-ellis-nginx-config
+++ b/root/usr/share/clearwater/infrastructure/scripts/create-ellis-nginx-config
@@ -22,6 +22,29 @@ then
   ssl_key_file=/etc/nginx/ssl/ellis.key
   temp_file=$(mktemp ellis.nginx.XXXXXXXX)
 
+  # Read common config into variables, to avoid duplication in this script.
+
+  read -r -d '' common_server_config << EOM
+        listen       [::]:80 default_server ipv6only=off;
+        server_name  $ellis_hostname $local_ip $public_ip $public_hostname;
+EOM
+
+  read -r -d '' location_config << EOM2
+        location / {
+                proxy_pass http://http_ellis;
+                proxy_http_version 1.1;
+
+                # The client may have instructed the server to close the
+                # connection - do not forward this upstream.
+                proxy_set_header Connection "";
+
+                # Preserve the Ellis hostname.
+                proxy_set_header Host $ellis_hostname;
+        }
+EOM2
+
+  # Write the ellis config to file, in multiple sections.
+
   cat > $temp_file << EOF1
 upstream http_ellis {
 EOF1
@@ -50,22 +73,11 @@ server {
         listen       [::]:443 ipv6only=off;
         server_name  $ellis_hostname $local_ip $public_ip $public_hostname;
 
-        location / {
-                proxy_pass http://http_ellis;
-                proxy_http_version 1.1;
-
-                # The client may have instructed the server to close the
-                # connection - do not forward this upstream.
-                proxy_set_header Connection "";
-
-                # Preserve the Ellis hostname.
-                proxy_set_header Host $ellis_hostname;
-        }
+        $location_config
 }
 
 server {
-        listen       [::]:80 default_server; # ipv6only=off is set in the base config
-        server_name  $ellis_hostname $local_ip $public_ip $public_hostname;
+        $common_server_config
 
         return       301   https://\$host\$request_uri;
 }
@@ -75,20 +87,9 @@ EOF3
 
     cat >> $temp_file << EOF4
 server {
-        listen       [::]:80 default_server ipv6only=off;
-        server_name  $ellis_hostname $local_ip $public_ip $public_hostname;
+        $common_server_config
 
-        location / {
-                proxy_pass http://http_ellis;
-                proxy_http_version 1.1;
-
-                # The client may have instructed the server to close the
-                # connection - do not forward this upstream.
-                proxy_set_header Connection "";
-
-                # Preserve the Ellis hostname.
-                proxy_set_header Host $ellis_hostname;
-        }
+        $location_config
 }
 EOF4
 

--- a/root/usr/share/clearwater/infrastructure/scripts/create-ellis-nginx-config
+++ b/root/usr/share/clearwater/infrastructure/scripts/create-ellis-nginx-config
@@ -75,7 +75,7 @@ EOF3
 
     cat >> $temp_file << EOF4
 server {
-        listen       [::]:80 default_server; # ipv6only=off is set in the base config
+        listen       [::]:80 default_server ipv6only=off;
         server_name  $ellis_hostname $local_ip $public_ip $public_hostname;
 
         location / {


### PR DESCRIPTION
This accompanies the change to the `ping` service in clearwater-nginx, see PR: Metaswitch/clearwater-nginx#46

This server relied on the `ipv6only=off` flag that was set in `ping`, which was also applied to Ellis after the two configs were merged, as they listened on the same address and port. With the above PR, `ping` will no longer be listening on the same address and port, so `ipv6only=off` must be specified.

I've tested this change directly by editing the `/etc/nginx/sites-available/ellis` file on an AWS PC deployment (along with the nginx change in the above PR). It is worth noting that this change will require a restart to clearwater-infrastructure to be picked up when a node upgrades to the new Ellis package.