### PR TITLE
[Reviewer: Adam] Add some output to create_user

### DIFF
--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -38,7 +38,7 @@ def main():
     if not utils.check_connection():
         sys.exit(1)
 
-    # We use sys.stout.write to print to stdout without a newline, so we can
+    # We use sys.stdout.write to print to stdout without a newline, so we can
     # indicate progress to the user
     sys.stdout.write("Creating users...")
     sys.stdout.flush()

--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -38,8 +38,16 @@ def main():
     if not utils.check_connection():
         sys.exit(1)
 
+    # We use sys.stout.write to print to stdout without a newline, so we can
+    # indicate progress to the user
+    sys.stdout.write("Creating users...")
+    sys.stdout.flush()
     success = True
+    count = 0
     for dn in utils.parse_dn_ranges(args.dns):
+        count += 1
+        sys.stdout.write(".")
+        sys.stdout.flush()
         public_id = "sip:%s@%s" % (dn, args.domain)
         private_id = "%s@%s" % (dn, args.domain)
 
@@ -49,10 +57,19 @@ def main():
         else:
             success = False
 
+        if count == 100:
+            print("")
+            print("Created up to user {}".format(dn))
+            count = 0
+
         if not success and not args.keep_going:
             break
 
-    sys.exit(0 if success else 1)
+    if success:
+        print("done")
+        sys.exit(0)
+    else:
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is a fix for: https://github.com/Metaswitch/clearwater-issues/issues/2269

It adds some output to the create_user script:
 - we print a `.` to the screen for every DN that we attempt to create
 - for every 10 DN that we've attempted, we print where we've got to so the user can see how far through the script has got

In combination, these two make it clear that the script is doing something and give a sense of the progress made so far.

The output looks like:

```
[dime-1]ubuntu@ec2-34-235-166-72:~$ /usr/share/clearwater/bin/create_user 3055555001..3055556000 sr2.cw-ngv.com secret
Creating users.......................................................................................................
Created up to user 3055555100
....................................................................................................
Created up to user 3055555200
....................................................................................................
Created up to user 3055555300
....................................................................................................

```
and at the end:
```
..........done
```

### Testing
- `make test`, `make verify` and `make analysis` all still pass
- live tested to check the output is sensible