### PR TITLE
[Reviewer: Seb] Rebuild the common wheel if it's cleaned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ include build-infra/python.mk
 # Ellis wheel
 
 # Add a target that builds the python-common wheel into the correct wheelhouse
-${ENV_DIR}/.ellis_build_common_wheel: common/requirements.txt $(shell find common/metaswitch -type f -not -name "*.pyc")
+# Depend on wheels-cleaned so that we rebuild it if it's deleted
+${ENV_DIR}/.ellis_build_common_wheel: common/requirements.txt $(shell find common/metaswitch -type f -not -name "*.pyc") ${ENV_DIR}/.wheels-cleaned
 	cd common && WHEELHOUSE=../ellis_wheelhouse make build_common_wheel
 	touch $@
 
@@ -44,7 +45,8 @@ $(eval $(call python_component,ellis))
 # Prov-tools wheel
 
 # Add a target that builds the python-common wheel into the correct wheelhouse
-${ENV_DIR}/.prov_tools_build_common_wheel: common/requirements.txt $(shell find common/metaswitch -type f -not -name "*.pyc")
+# Depend on wheels-cleaned so that we rebuild it if it's deleted
+${ENV_DIR}/.prov_tools_build_common_wheel: common/requirements.txt $(shell find common/metaswitch -type f -not -name "*.pyc") ${ENV_DIR}/.wheels-cleaned
 	cd common && WHEELHOUSE=../prov_tools_wheelhouse make build_common_wheel
 	touch $@
 


### PR DESCRIPTION
Seb,

This resolves a problem where the common wheel isn't rebuilt when required, causing builds to fail.

I've tested this by:

- Running `make deb` and checking it built everything.
- Re-running `make deb` and checking it didn't rebuild anything
- Touching `src/metaswitch/ellis/main.py`, rerunning `make deb` and checking everything get's correctly rebuilt.