### PR TITLE
[Reviewer: KH1] Cannot delete user in dgn

### DIFF
--- a/src/metaswitch/ellis/prov_tools/utils.py
+++ b/src/metaswitch/ellis/prov_tools/utils.py
@@ -77,6 +77,11 @@ def build_ifc(ifc_file, domain, twin_prefix):
         except IOError as e:
             _log.error("Failed to read %s - %s", ifc_file, e.strerror)
             return None
+        try:
+            homestead._validate_ifc_file(ifc)
+        except ValueError as e:
+            _log.error("IFC validation failed - %s", e)
+            return None
     else:
         ifc=('<?xml version="1.0" ?>\n'
               '<ServiceProfile>\n'

--- a/src/metaswitch/ellis/remote/homestead.py
+++ b/src/metaswitch/ellis/remote/homestead.py
@@ -14,6 +14,7 @@ import json
 import re
 import datetime
 import time
+import xml.dom.minidom
 
 from tornado import httpclient
 from tornado.ioloop import IOLoop
@@ -216,6 +217,12 @@ def put_filter_criteria(public_id, ifcs, callback):
     Updates the initial filter criteria in Homestead for the given line.
     callback receives the HTTPResponse object.
     """
+    try:
+        _validate_ifc_file(ifcs)
+    except ValueError as e:
+        _log.error("The initial filter criteria cannot be uploaded as the iFC file \
+                   provided is not a valid XML file - %s", e)
+        raise
     sp_url = _sp_from_public_id_url(public_id)
     resp = _sync_http_request(sp_url, method='GET')
     if isinstance(resp, HTTPError): # pragma: no cover

--- a/src/metaswitch/ellis/remote/homestead.py
+++ b/src/metaswitch/ellis/remote/homestead.py
@@ -421,3 +421,10 @@ def _get_sp_uuid(url):
     if not match: # pragma: no cover
         raise ValueError("URL %s is badly formatted: expected it to match %s" % (url, re_str))
     return match.group(1)
+
+def _validate_ifc_file(ifc_file):
+    """Checks whether ifc_file is a valid XML file. Raises a ValueError if not."""
+    try:
+        xml.dom.minidom.parseString(ifc_file)
+    except Exception as e:
+        raise ValueError("The XML file containing the iFC is malformed.", e)


### PR DESCRIPTION
Hi Krista, would you mind reviewing this?

This fix addresses Issue 514812, where a user created in homestead-prov with malformed XML file containing the Initial Filter Criteria (IFC) could not be deleted.
The fix doesn't fix the delete user script itself, instead it prevents the problem from arising in the first place. It does this by not allowing a malformed XML file containing the IFC to be uploaded to the subscriber database. The code that does this simply throws a ValueError and lets the client side (i.e. the create_user.py script) handle the error appropriately. In this case, the user simply is not created (the build_ifc function in utils.py returns 'None' which leads to sys.exit(1) in the create_user.py script).

I have tested the code without including the change to the client side (i.e. utils.py) , to test whether the server side throws the desired ValueError, and then also with the client side change included, which appropriately raises a ValueError and exits user creation so that the user is not created.