### PR TITLE
[Reviewer: Sathiyan] Add setting the IMPI

### DIFF
--- a/src/metaswitch/ellis/prov_tools/create_user.py
+++ b/src/metaswitch/ellis/prov_tools/create_user.py
@@ -24,6 +24,7 @@ def main():
     parser.add_argument("--plaintext", action="store_true", help="store password in plaintext")
     parser.add_argument("--ifc", metavar="iFC-FILE", action="store", dest="ifc_file", help="XML file containing the iFC")
     parser.add_argument("--prefix", action="store", default="123", dest="twin_prefix", help="twin-prefix (default: 123)")
+    parser.add_argument("--impi", action="store", default="", dest="impi", help="IMPI (default: derived from the IMPU)")
     parser.add_argument("dns", metavar="<directory-number>[..<directory-number>]")
     parser.add_argument("domain", metavar="<domain>")
     parser.add_argument("password", metavar="<password>")
@@ -50,6 +51,9 @@ def main():
         sys.stdout.flush()
         public_id = "sip:%s@%s" % (dn, args.domain)
         private_id = "%s@%s" % (dn, args.domain)
+
+        if args.impi != "":
+            private_id = args.impi
 
         if utils.create_user(private_id, public_id, args.domain, args.password, ifc, plaintext=args.plaintext):
             if not utils.display_user(public_id, quiet=True):


### PR DESCRIPTION
This PR adds the ability to set the IMPI when creating a user.

Users pass in --impi <impi> as a parameter to create_user. If they don't, the IMPI is derived from the IMPU.

The IMPI is at the same level as the password - so if you are creating a range of users then they'll all have the same IMPI - this is a bit rubbish, but it's sufficient for the use case.

Tested live (there aren't any UTs).